### PR TITLE
Add AudioEngineWwise 1.0.0 remote gem

### DIFF
--- a/src/repo.json
+++ b/src/repo.json
@@ -288,6 +288,38 @@
                     "version": "1.0.0"
                 }
             ]
+        },
+        {
+            "gem_name": "AudioEngineWwise",
+            "version": "1.0.0",
+            "display_name": "Wwise Audio Engine",
+            "license": "Apache-2.0 Or MIT",
+            "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
+            "origin": "O3DE Extras",
+            "origin_url": "https://github.com/o3de/o3de-extras/development/Gems/AudioEngineWwise",
+            "type": "Code",
+            "summary": "The Wwise Audio Engine Gem provides support for Audiokinetic Wave Works Interactive Sound Engine (Wwise).",
+            "canonical_tags": [
+                "Gem"
+            ],
+            "user_tags": [
+                "Audio",
+                "Utility",
+                "Tools"
+            ],
+            "compatible_engines": [
+                "o3de-sdk>=2.1.0",
+                "o3de>=2.1.0"
+            ],
+            "icon_path": "preview.png",
+            "requirements": "Users will need to download Wwise from the <a href='https://www.audiokinetic.com/download/'>Audiokinetic Web Site</a>.",
+            "documentation_url": "https://o3de.org/docs/user-guide/gems/reference/audio/wwise/audio-engine-wwise/",
+            "dependencies": [
+                "AudioSystem"
+            ],
+            "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
+            "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/audioenginewwise-1.0.0-gem.zip",
+            "sha256": "5bb813e841e45cbe9d195ca50815963df8d7d57def266f6a6a765d9b786b0d83"
         }
     ],
     "templates": [

--- a/src/repo.json
+++ b/src/repo.json
@@ -4,7 +4,7 @@
     "repo_uri": "https://canonical.o3de.org",
     "summary": "The Open 3D Engine's canonical repos.",
     "additional_info": "Get more information about this repo at https://github.com/o3de/canonical.o3de.org",
-    "last_updated": "2023-10-09",
+    "last_updated": "2024-01-17",
     "$schemaVersion": "1.0.0",
     "gems_data": [
         {


### PR DESCRIPTION
This change brings over the repo.json from the o3de-extras/development branch
https://github.com/o3de/o3de-extras/blob/576ff6c/repo.json

- Adds AudioEngineWwise 1.0.0 remote gem
- Updates last_updated field to today

The testing and details of the changes are part of this o3de-extras PR https://github.com/o3de/o3de-extras/pull/637

I tested this change by adding the following remote repository URL: 
https://raw.githubusercontent.com/AMZN-alexpete/canonical.o3de.org/AMZN-alexpete/remote-content-23102-wwise/src/ ...after which I could see AudioEngineWwise as an included gem:
![image](https://github.com/o3de/canonical.o3de.org/assets/26804013/63ca179f-c4d4-45c9-8ccb-7667595a33c3)
...and was able to use it in projects:
![image](https://github.com/o3de/canonical.o3de.org/assets/26804013/e5c21736-53eb-4c76-8943-117442b3e979)
...and run the Editor to verify audio could be heard.
