### PR TITLE
Fix WarehouseAssets Gem (updated SHA)

### DIFF
--- a/src/repo.json
+++ b/src/repo.json
@@ -4,7 +4,7 @@
     "repo_uri": "https://canonical.o3de.org",
     "summary": "The Open 3D Engine's canonical repos.",
     "additional_info": "Get more information about this repo at https://github.com/o3de/canonical.o3de.org",
-    "last_updated": "2025-05-26",
+    "last_updated": "2025-06-18",
     "$schemaVersion": "1.0.0",
     "gems_data": [
         {
@@ -432,7 +432,7 @@
                         "o3de>=2.3.0"
                     ],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehouseassets-2.0.0-gem.zip",
-                    "sha256": "2f983dbf19be64c9de9217cfa88c91b3dc1a59e08d57eb07b348cfbc2fb00f5e"
+                    "sha256": "b91c685ea476523322b2864d17aafc5c6236092f950a4159fe59051d9c9449ce"
                 }
             ]
         },


### PR DESCRIPTION
There was a problem in `gem.json` file in `WarehouseAssets` Gem in _o3de-extras_. The following empty data value is required to make it working correctly in _ProjectManager_:
```json
"engine_api_dependencies": []
```
It was removed in PR #840 in _o3de-extras_ in https://github.com/o3de/o3de-extras/pull/840/files#diff-70e2e613293787b72b69923e979f4f120054b876959bf7e299a2b9e3a1e71e41

Without this data, _ProjectManager_ downloads the file, but discovers the missing data value and terminates:
![Screenshot from 2025-06-17 19-23-03](https://github.com/user-attachments/assets/12220cfa-c599-4a35-8aab-94ade9b9338f)

The missing part was added to `gem.json,` and the package was regenerated and uploaded as a new release. Due to the changes, SHA was updated. The PR (targeting the `development` branch) in _o3de-extras_ is ready: https://github.com/o3de/o3de-extras/pull/924

The change was tested by uploading a binary to a separate repository (with a bumped version) and manually adding a second `repo.json` file. The file used for tests: 
[repo.json](https://github.com/user-attachments/files/20795456/repo.json)