### PR TITLE
Add multiplayer template 2.1.1 bugfix release

### DIFF
--- a/src/repo.json
+++ b/src/repo.json
@@ -4,7 +4,7 @@
     "repo_uri": "https://canonical.o3de.org",
     "summary": "The Open 3D Engine's canonical repos.",
     "additional_info": "Get more information about this repo at https://github.com/o3de/canonical.o3de.org",
-    "last_updated": "2025-05-12",
+    "last_updated": "2025-05-29",
     "$schemaVersion": "1.0.0",
     "gems_data": [
         {
@@ -2729,6 +2729,11 @@
                     "version": "2.1.0",
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/multiplayer-2.1.0-template.zip",
                     "sha256": "4020f7cbbca61acdddb71ec0054798aa6ea6bd47d3b56547754bd8e1f3562420"
+                },
+                {
+                    "version": "2.1.1",
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/multiplayer-2.1.1-template.zip",
+                    "sha256": "82cc1fea13d68820f6fa6129e2fbf59732984ed0f27b48f065e7d86e26c621a2"
                 }
             ]
         },


### PR DESCRIPTION
One more release was done after 2605.0 as a fix to critical issue in Multiplayer Template: release 2.1.1.

This is added in this PR.